### PR TITLE
Bump jcl-over-slf4j to 2.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.17</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Aligns the SLF4J family with slf4j-api 2.0.17 used across the stack (Jena 6.1.0); jcl-over-slf4j was the last artifact still on 1.7.36.