### PR TITLE
Drop dead cacheModelLoads and preemptiveAuth config flags

### DIFF
--- a/src/main/java/com/atomgraph/core/Application.java
+++ b/src/main/java/com/atomgraph/core/Application.java
@@ -69,7 +69,6 @@ public class Application extends ResourceConfig implements com.atomgraph.core.mo
     private final MediaTypes mediaTypes;
     private final Client client;
     private final Integer maxGetRequestSize;
-    private final boolean preemptiveAuth;
 
     /**
      * Initializes root resource classes and provider singletons
@@ -86,24 +85,20 @@ public class Application extends ResourceConfig implements com.atomgraph.core.mo
             servletConfig.getInitParameter(A.authUser.getURI()) != null ? servletConfig.getInitParameter(A.authUser.getURI()) : null,
             servletConfig.getInitParameter(A.authPwd.getURI()) != null ? servletConfig.getInitParameter(A.authPwd.getURI()) : null,
             new MediaTypes(), getClient(new ClientConfig()),
-            servletConfig.getInitParameter(A.maxGetRequestSize.getURI()) != null ? Integer.valueOf(servletConfig.getInitParameter(A.maxGetRequestSize.getURI())) : null,
-            servletConfig.getInitParameter(A.cacheModelLoads.getURI()) != null ? Boolean.parseBoolean(servletConfig.getInitParameter(A.cacheModelLoads.getURI())) : false,
-            servletConfig.getInitParameter(A.preemptiveAuth.getURI()) != null ? Boolean.parseBoolean(servletConfig.getInitParameter(A.preemptiveAuth.getURI())) : false
+            servletConfig.getInitParameter(A.maxGetRequestSize.getURI()) != null ? Integer.valueOf(servletConfig.getInitParameter(A.maxGetRequestSize.getURI())) : null
         );
     }
-    
+
     public Application(final Dataset dataset,
             final String endpointURI, final String graphStoreURI, final String quadStoreURI,
             final String authUser, final String authPwd,
-            final MediaTypes mediaTypes, final Client client, final Integer maxGetRequestSize,
-            final boolean cacheModelLoads, final boolean preemptiveAuth)
+            final MediaTypes mediaTypes, final Client client, final Integer maxGetRequestSize)
     {
         this.dataset = dataset;
         this.mediaTypes = mediaTypes;
         this.client = client;
         this.maxGetRequestSize = maxGetRequestSize;
-        this.preemptiveAuth = preemptiveAuth;
-        
+
         // add RDF/POST serializer
         RDFLanguages.register(RDFLanguages.RDFPOST);
         RDFParserRegistry.registerLangTriples(RDFLanguages.RDFPOST, new RDFPostReaderFactory());
@@ -199,11 +194,6 @@ public class Application extends ResourceConfig implements com.atomgraph.core.mo
     }    
 
     
-    public boolean isPreemptiveAuth()
-    {
-        return preemptiveAuth;
-    }
-
     public static Dataset getDataset(String location, Lang lang)
     {
         Dataset dataset = DatasetFactory.createTxnMem();

--- a/src/main/java/com/atomgraph/core/vocabulary/A.java
+++ b/src/main/java/com/atomgraph/core/vocabulary/A.java
@@ -66,12 +66,6 @@ public final class A
     /** Result limit property */
     public static final Property resultLimit = m_model.createDataProperty( NS + "resultLimit" );
 
-    /** Cache models property */
-    public static final Property cacheModelLoads = m_model.createDataProperty( NS + "cacheModelLoads" );
-    
-    /** Preemptive HTTP Basic auth property */
-    public static final Property preemptiveAuth = m_model.createDataProperty( NS + "preemptiveAuth" );
-    
     /** Max <code>GET</code> request size property */
     public static final Property maxGetRequestSize = m_model.createDataProperty( NS + "maxGetRequestSize" );
     

--- a/src/main/resources/com/atomgraph/core/ns.ttl
+++ b/src/main/resources/com/atomgraph/core/ns.ttl
@@ -21,12 +21,6 @@
     rdfs:seeAlso sd:service ;
     rdfs:isDefinedBy <#> .
 
-:preemptiveAuth a owl:DatatypeProperty ;
-    rdfs:range xsd:boolean ;
-    rdfs:label "Preemptive authentication" ;
-    rdfs:seeAlso <http://tools.ietf.org/html/rfc2617#section-2> ;
-    rdfs:isDefinedBy <#> .
-
 :cacheControl a owl:DatatypeProperty ;
     rdfs:subPropertyOf http:fieldValue ;
     rdfs:range xsd:string ;

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -29,10 +29,6 @@
         </init-param>
         -->
         <init-param>
-            <param-name>https://w3id.org/atomgraph/core#preemptiveAuth</param-name>
-            <param-value>true</param-value>
-        </init-param>
-        <init-param>
             <param-name>https://w3id.org/atomgraph/core#cacheControl</param-name>
             <param-value>no-cache</param-value>
         </init-param>

--- a/src/test/java/com/atomgraph/core/client/GraphStoreClientTest.java
+++ b/src/test/java/com/atomgraph/core/client/GraphStoreClientTest.java
@@ -71,7 +71,7 @@ public class GraphStoreClientTest extends JerseyTest
         system = new com.atomgraph.core.Application(getDataset(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         
         return system;

--- a/src/test/java/com/atomgraph/core/io/ModelProviderTest.java
+++ b/src/test/java/com/atomgraph/core/io/ModelProviderTest.java
@@ -58,7 +58,7 @@ public class ModelProviderTest extends JerseyTest
         system = new com.atomgraph.core.Application(DatasetFactory.createTxnMem(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         
         return system;

--- a/src/test/java/com/atomgraph/core/model/impl/DirectGraphStoreTest.java
+++ b/src/test/java/com/atomgraph/core/model/impl/DirectGraphStoreTest.java
@@ -103,7 +103,7 @@ public class DirectGraphStoreTest extends JerseyTest
         system = new com.atomgraph.core.Application(getDataset(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         system.register(TestResource.class);
         

--- a/src/test/java/com/atomgraph/core/model/impl/GraphStoreImplTest.java
+++ b/src/test/java/com/atomgraph/core/model/impl/GraphStoreImplTest.java
@@ -91,7 +91,7 @@ public class GraphStoreImplTest extends JerseyTest
         system = new com.atomgraph.core.Application(getDataset(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         
         return system;

--- a/src/test/java/com/atomgraph/core/model/impl/LocaleEntityTagTest.java
+++ b/src/test/java/com/atomgraph/core/model/impl/LocaleEntityTagTest.java
@@ -134,7 +134,7 @@ public class LocaleEntityTagTest extends JerseyTest
         system = new com.atomgraph.core.Application(getDataset(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         system.register(TestResource.class);
         system.register(LangSpecificTestResource.class);

--- a/src/test/java/com/atomgraph/core/model/impl/SPARQLEndpointImplTest.java
+++ b/src/test/java/com/atomgraph/core/model/impl/SPARQLEndpointImplTest.java
@@ -91,7 +91,7 @@ public class SPARQLEndpointImplTest extends JerseyTest
         system = new com.atomgraph.core.Application(getDataset(),
                 null, null, null, null, null,
                 new MediaTypes(), com.atomgraph.core.Application.getClient(new ClientConfig()),
-                null, false, false);
+                null);
         system.init();
         
         return system;


### PR DESCRIPTION
Both were parsed from web.xml and threaded through the Application constructor but read by nothing after the Jena 6 / ont-api migration: the DocumentGraphRepository caches unconditionally (no re-fetch toggle), and authenticated dereferencing is done by per-WebTarget delegation filters rather than preemptive HTTP Basic auth. Removes the constructor params, the isPreemptiveAuth() getter, the A vocabulary constants, the ns.ttl definition and the web.xml param; updates test call sites.